### PR TITLE
DATA-1581 use show tables like instead of describe in existence check

### DIFF
--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -113,7 +113,7 @@ class HiveCommandClient(HiveClient):
                 return line.split("\t")[1]
 
     def table_exists(self, table, database='default', partition={}):
-        cmd = "use {0}; describe {1}".format(database, table)
+        cmd = "use {0}; show tables like '{1}'".format(database, table)
         if partition:
             cmd = "use {0}; show partitions {1} partition ({2})".format(database, table, self.partition_spec(partition))
 


### PR DESCRIPTION
@akaul r?

This is the line I'm referring to: https://github.com/spotify/luigi/blob/master/luigi/contrib/hive.py#L139

This has been tested on both es backed and s3 backed hive tables (both for the exists and doesn't exist cases).

I also confirmed that this will only match the table with the exact name specified.

This is done so the tables backed by elasticsearch can be checked for
existence without having to load the es-hadoop jar.

This matches what is used in the main luigi master branch.
