### PR TITLE
retcodes: Understand succesful retries (#1951)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,3 @@ before_script:
 script:
   - tox --version
   - ./scripts/ci/conditional_tox.sh
-
-branches:
-  only:
-    - master

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -43,11 +43,13 @@ def _partition_tasks(worker):
     set_tasks["completed"] = {task for (task, status, ext) in task_history if status == 'DONE' and task in pending_tasks}
     set_tasks["already_done"] = {task for (task, status, ext) in task_history
                                  if status == 'DONE' and task not in pending_tasks and task not in set_tasks["completed"]}
-    set_tasks["failed"] = {task for (task, status, ext) in task_history if status == 'FAILED'}
+    set_tasks["ever_failed"] = {task for (task, status, ext) in task_history if status == 'FAILED'}
+    set_tasks["failed"] = set_tasks["ever_failed"] - set_tasks["completed"]
+    set_tasks["scheduling_error"] = {task for(task, status, ext) in task_history if status == 'UNKNOWN'}
     set_tasks["still_pending_ext"] = {task for (task, status, ext) in task_history
-                                      if status == 'PENDING' and task not in set_tasks["failed"] and task not in set_tasks["completed"] and not ext}
+                                      if status == 'PENDING' and task not in set_tasks["ever_failed"] and task not in set_tasks["completed"] and not ext}
     set_tasks["still_pending_not_ext"] = {task for (task, status, ext) in task_history
-                                          if status == 'PENDING' and task not in set_tasks["failed"] and task not in set_tasks["completed"] and ext}
+                                          if status == 'PENDING' and task not in set_tasks["ever_failed"] and task not in set_tasks["completed"] and ext}
     set_tasks["run_by_other_worker"] = set()
     set_tasks["upstream_failure"] = set()
     set_tasks["upstream_missing_dependency"] = set()
@@ -77,7 +79,7 @@ def _depth_first_search(set_tasks, current_task, visited):
         for task in current_task._requires():
             if task not in visited:
                 _depth_first_search(set_tasks, task, visited)
-            if task in set_tasks["failed"] or task in set_tasks["upstream_failure"]:
+            if task in set_tasks["ever_failed"] or task in set_tasks["upstream_failure"]:
                 set_tasks["upstream_failure"].add(current_task)
                 upstream_failure = True
             if task in set_tasks["still_pending_ext"] or task in set_tasks["upstream_missing_dependency"]:
@@ -247,7 +249,9 @@ def _get_comments(group_tasks):
 _ORDERED_STATUSES = (
     "already_done",
     "completed",
+    "ever_failed",
     "failed",
+    "scheduling_error",
     "still_pending",
     "still_pending_ext",
     "run_by_other_worker",
@@ -355,9 +359,18 @@ def _summary_format(set_tasks, worker):
         str_output += 'Did not run any tasks'
     smiley = ""
     reason = ""
-    if set_tasks["failed"]:
+    if set_tasks["ever_failed"]:
+        if not set_tasks["failed"]:
+            smiley = ":)"
+            reason = "there were failed tasks but they all suceeded in a retry"
+        else:
+            smiley = ":("
+            reason = "there were failed tasks"
+            if set_tasks["scheduling_error"]:
+                reason += " and tasks whose scheduling failed"
+    elif set_tasks["scheduling_error"]:
         smiley = ":("
-        reason = "there were failed tasks"
+        reason = "there were tasks whose scheduling failed"
     elif set_tasks["still_pending_ext"]:
         smiley = ":|"
         reason = "there were missing external dependencies"

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -784,6 +784,12 @@ class DictParameter(Parameter):
                 return obj.get_wrapped()
             return json.JSONEncoder.default(self, obj)
 
+    def normalize(self, value):
+        """
+        Ensure that dictionary parameter is converted to a FrozenOrderedDict so it can be hashed.
+        """
+        return FrozenOrderedDict(value)
+
     def parse(self, s):
         """
         Parses an immutable and ordered ``dict`` from a JSON string using standard JSON library.

--- a/test/retcodes_test.py
+++ b/test/retcodes_test.py
@@ -108,3 +108,39 @@ class RetcodesTest(LuigiTestCase):
 
         self.run_and_expect('RequiringTask --retcode-task-failed 4 --retcode-missing-data 5', 5)
         self.run_and_expect('RequiringTask --retcode-task-failed 7 --retcode-missing-data 6', 7)
+
+    def test_unknown_reason(self):
+
+        class TaskA(luigi.Task):
+            def complete(self):
+                return True
+
+        class RequiringTask(luigi.Task):
+            def requires(self):
+                yield TaskA()
+
+        def new_func(*args, **kwargs):
+            return None
+
+        with mock.patch('luigi.scheduler.Scheduler.add_task', new_func):
+            self.run_and_expect('RequiringTask', 0)
+            self.run_and_expect('RequiringTask --retcode-not-run 5', 5)
+
+    """
+    Test that a task once crashing and then succeeding should be counted as no failure.
+    """
+    def test_retry_sucess_task(self):
+        class Foo(luigi.Task):
+            run_count = 0
+
+            def run(self):
+                self.run_count += 1
+                if self.run_count == 1:
+                    raise ValueError()
+
+            def complete(self):
+                return self.run_count > 0
+
+        self.run_and_expect('Foo --scheduler-retry-delay=0', 0)
+        self.run_and_expect('Foo --scheduler-retry-delay=0 --retcode-task-failed=5', 0)
+        self.run_with_config(dict(task_failed='3'), 'Foo', 0)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps=
   psutil<4.0
   enum34>1.1.0
   cdh,hdp: snakebite>=2.5.2,<2.6.0
-  cdh,hdp: hdfs>=2.0.4,<3.0.0  # The webhdfs library
+  cdh,hdp: hdfs>=2.0.4,<3.0.0
   postgres: psycopg2<3.0
   gcloud: google-api-python-client>=1.4.0,<2.0
   coverage>=3.6,<3.999


### PR DESCRIPTION
Prior to this commit, the return codes from luigi didn't honor the case when a task once failed but then succeeded again in a following retry. This will both make the execution summary and return code correct. This fixes #1932.